### PR TITLE
Fix date parsing, improve preview & add shorthand support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build .alfredworkflow
+        run: python scripts/build.py
+
+      - name: Get artifact path
+        id: artifact
+        run: |
+          FILE=$(ls dist/*.alfredworkflow)
+          echo "path=$FILE" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename $FILE)" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.artifact.outputs.path }}
+          generate_release_notes: true

--- a/workflow/calendar_nlp.py
+++ b/workflow/calendar_nlp.py
@@ -65,7 +65,8 @@ class CalendarNLPProcessor:
         self.calendars = self.get_available_calendars()
         self.config = self.load_config()
         self.calendar_pattern = r'#(?:"([^"]+)"|\'([^\']+)\'|([^"\'\s]+))'
-        self.time_pattern = r'\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b'
+        # Require am/pm for bare hours to avoid matching date/day numbers
+        self.time_pattern = r'\b(\d{1,2}):(\d{2})\s*(am|pm)?\b|\b(\d{1,2})\s*(am|pm)\b'
         self.relative_time_pattern = r'in\s+(\d+)\s+(minutes?|hours?)'
         self.date_range_pattern = r'from\s+(\w+\s+\d{1,2}|\d{1,2}/\d{1,2}(?:/\d{2,4})?)\s*(?:-|to)\s*(\w+\s+\d{1,2}|\d{1,2}/\d{1,2}(?:/\d{2,4})?)'
         self.duration_patterns = {
@@ -218,7 +219,7 @@ class CalendarNLPProcessor:
 
     def parse_duration(self, text: str) -> int:
         """Extract duration in minutes from text"""
-        # First check for time range (e.g., "5-6pm")
+        # First check for time range (e.g., "3-5pm")
         range_match = re.search(self.duration_patterns['time_range'], text, re.IGNORECASE)
         if range_match:
             start_hour, start_min, end_hour, end_min = range_match.groups()
@@ -226,14 +227,16 @@ class CalendarNLPProcessor:
             start_min = int(start_min) if start_min else 0
             end_hour = int(end_hour)
             end_min = int(end_min) if end_min else 0
-            
-            # Convert to 24-hour format if needed
-            if 'pm' in text.lower():
-                if start_hour != 12:
-                    start_hour += 12
+
+            # Detect meridiem from the matched portion and propagate to start
+            matched = range_match.group(0).lower()
+            if 'pm' in matched:
                 if end_hour != 12:
                     end_hour += 12
-            
+                # Propagate pm to start only if start hour is plausible (< end)
+                if start_hour != 12 and start_hour < end_hour:
+                    start_hour += 12
+
             duration_minutes = (end_hour * 60 + end_min) - (start_hour * 60 + start_min)
             if duration_minutes > 0:
                 return duration_minutes
@@ -257,33 +260,50 @@ class CalendarNLPProcessor:
 
     def clean_title(self, text: str) -> str:
         """Clean up the title"""
-        # First clean recurrence and date/time info
-        patterns_to_remove = [
-            r'\bevery\b\s+\w+',  # Remove "every" patterns
-            r'\b(?:tomorrow|today|next|on|at|from|to|daily|weekly|monthly)\b.*$',
-            r'\bon\s+(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?',  # Remove "on weekday"
-            r'\b(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?',  # Remove weekday mentions
-            r'\d{1,2}(?::\d{2})?\s*(?:am|pm).*$',
-            r'for\s+\d+\s+(?:day|hour|minute|min)s?.*$',
-            r'(?:alert|remind).*$',
-            r'with\s+\d+\s*(?:minute|min|hour)s?\s+(?:alert|reminder)',
-            r'url\s+https?://\S+'
-        ]
-        
         title = text
+        patterns_to_remove = [
+            # Recurrence
+            r'\bevery\s+\w+',
+            r'\bdaily\b|\bweekly\b|\bmonthly\b|\bannually\b|\byearly\b',
+            # Weekdays
+            r'\bon\s+(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b',
+            r'\b(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b',
+            # Relative dates (standalone)
+            r'\btomorrow\b|\btoday\b',
+            r'\bnext\s+(?:week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b',
+            # Explicit dates: "March 20", "20 March"
+            r'\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?!:\d{2})\b',
+            r'\b\d{1,2}(?!:\d{2})\s+(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b',
+            # Time ranges like "3-5pm" — must come before bare time patterns
+            r'\b\d{1,2}(?::\d{2})?\s*(?:am|pm)?\s*-\s*\d{1,2}(?::\d{2})?\s*(?:am|pm)\b',
+            # Time: "at 3pm", "at 15:15", "3pm", "15:15"
+            r'\bat\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?\b',
+            r'\b\d{1,2}:\d{2}\s*(?:am|pm)?\b',
+            r'\b\d{1,2}\s*(?:am|pm)\b',
+            # Duration
+            r'\bfor\s+\d+(?:\.\d+)?\s*(?:day|hour|hr|minute|min)s?\b',
+            # Alerts
+            r'\bwith\s+\d+\s*(?:minute|min|hour)s?\s+(?:alert|reminder)\b',
+            r'\b(?:alert|remind)\s+\d+\s*(?:minute|min|hour)s?\s+before\b',
+            # Date range prepositions
+            r'\bfrom\b|\bto\b|\bon\b|\bat\b',
+            # URLs
+            r'url\s+https?://\S+',
+        ]
+
         for pattern in patterns_to_remove:
             title = re.sub(pattern, '', title, flags=re.IGNORECASE)
-        
+
         # Remove URLs and notes
         for pattern in self.url_patterns + self.notes_patterns:
             title = re.sub(pattern, '', title, flags=re.IGNORECASE)
-        
+
         # Clean up remaining artifacts
         title = re.sub(r'\s+for\s*$', '', title)
         title = re.sub(r'\s+in\s*$', '', title)
         title = re.sub(r'\s+at\s*$', '', title)
         title = re.sub(r'\s+', ' ', title)
-        
+
         return title.strip()
 
     def parse_location(self, text: str) -> Optional[str]:
@@ -460,24 +480,67 @@ class CalendarNLPProcessor:
                 return now + timedelta(minutes=amount)
                 
         # Regular time pattern
+        # First check for time range — return the START time
+        range_match = re.search(
+            r'(\d{1,2})(?::(\d{2}))?\s*(?:am|pm)?\s*-\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)',
+            text, re.IGNORECASE
+        )
+        if range_match:
+            sh = int(range_match.group(1))
+            sm = int(range_match.group(2)) if range_match.group(2) else 0
+            emer = range_match.group(5).lower()
+            # Propagate end meridiem to start
+            if emer == 'pm' and sh != 12:
+                sh += 12
+            elif emer == 'am' and sh == 12:
+                sh = 0
+            return base_date.replace(hour=sh, minute=sm, second=0, microsecond=0)
+
         match = re.search(self.time_pattern, text, re.IGNORECASE)
         if match:
-            hour = int(match.group(1))
-            minutes = int(match.group(2)) if match.group(2) else 0
-            meridiem = match.group(3).lower() if match.group(3) else ''
-            
+            if match.group(1) is not None:  # HH:MM format
+                hour = int(match.group(1))
+                minutes = int(match.group(2))
+                meridiem = match.group(3).lower() if match.group(3) else ''
+            else:  # bare number with required am/pm
+                hour = int(match.group(4))
+                minutes = 0
+                meridiem = match.group(5).lower()
+
             # Handle PM times
             if meridiem == 'pm' and hour != 12:
                 hour += 12
             elif meridiem == 'am' and hour == 12:
                 hour = 0
-                
+
             return base_date.replace(hour=hour, minute=minutes, second=0, microsecond=0)
             
         return base_date
 
+    def expand_shorthands(self, text: str) -> str:
+        """Expand common shorthand terms before parsing"""
+        replacements = [
+            (r'\btmrw\b|\btmr\b|\btmro\b', 'tomorrow'),
+            (r'\btod\b|\btdy\b|\btoday\b', 'today'),
+            (r'\bnxt wk\b|\bnxt week\b|\bnw\b', 'next week'),
+            (r'\bw/\b', 'with'),
+            (r'\beve\b', 'evening'),
+            (r'\bmtg\b|\bmeet\b', 'meeting'),
+            (r'\bapt\b|\bappt\b', 'appointment'),
+            (r'\bdr\b', 'doctor'),
+            (r'\bwfh\b', 'work from home'),
+            (r'\blunch\b', 'lunch'),
+            (r'\b(\d+)m\b(?!arch|ay)', 'for \\1 minutes'),
+            (r'\b(\d+)h\b(?!our)', 'for \\1 hours'),
+        ]
+        result = text
+        for pattern, replacement in replacements:
+            result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+        return result
+
     def parse_event(self, text: str) -> dict:
         try:
+            text = self.expand_shorthands(text)
             url, notes = self.parse_url_and_notes(text)
             clean_text = self._clean_text_for_parsing(text, url)
             
@@ -548,7 +611,15 @@ class CalendarNLPProcessor:
                 if days_ahead == 0:  # If it's the same day, move to next week
                     days_ahead = 7
                 return today + timedelta(days=days_ahead)
-                
+
+        # Try to extract an explicit date (e.g. "March 20", "17 March", "20/3")
+        try:
+            parsed = parser.parse(text, default=today, fuzzy=True)
+            if parsed.date() != today.date():
+                return parsed
+        except (ValueError, OverflowError):
+            pass
+
         return today
     
     def _add_optional_fields(self, event_details: dict, text: str, url: Optional[str], notes: Optional[str]):
@@ -649,16 +720,16 @@ def create_calendar_event(event_details: dict) -> str:
             raise Exception(result.stderr)
         
         # Format notification...
-        time_str = start_date.strftime("%-I:%M %p")
+        time_str = f"{start_date.strftime('%-I:%M %p')} – {end_date.strftime('%-I:%M %p')}"
         today = datetime.now()
         tomorrow = today + timedelta(days=1)
-        
+
         if start_date.date() == today.date():
             date_str = f"Today at {time_str}"
         elif start_date.date() == tomorrow.date():
             date_str = f"Tomorrow at {time_str}"
         else:
-            date_str = start_date.strftime("%A, %B %-d at %I:%M %p")
+            date_str = start_date.strftime("%A, %B %-d at ") + time_str
         
         notification_details = f"📅 {event_details['calendar']} • {date_str}"
         if 'location' in event_details:

--- a/workflow/calendar_nlp.py
+++ b/workflow/calendar_nlp.py
@@ -601,8 +601,20 @@ class CalendarNLPProcessor:
             return today + timedelta(days=1)
         elif 'next week' in text_lower:
             return today + timedelta(days=7)
-        
-        # Handle specific weekdays
+
+        # Try fuzzy date parsing first — handles "March 20", "17 March", "Tuesday 24 March",
+        # etc. This must run before bare weekday matching so "Tuesday 24 March" resolves
+        # to March 24, not next Tuesday.
+        try:
+            parsed = parser.parse(text, default=today, fuzzy=True)
+            if parsed.date() != today.date():
+                if parsed.date() < today.date():
+                    parsed = parsed.replace(year=parsed.year + 1)
+                return parsed
+        except (ValueError, OverflowError):
+            pass
+
+        # Fall back to weekday-only matching (e.g., "meeting on Thursday")
         for day in self.weekday_map:
             if day in text_lower:
                 current_weekday = today.weekday()
@@ -611,14 +623,6 @@ class CalendarNLPProcessor:
                 if days_ahead == 0:  # If it's the same day, move to next week
                     days_ahead = 7
                 return today + timedelta(days=days_ahead)
-
-        # Try to extract an explicit date (e.g. "March 20", "17 March", "20/3")
-        try:
-            parsed = parser.parse(text, default=today, fuzzy=True)
-            if parsed.date() != today.date():
-                return parsed
-        except (ValueError, OverflowError):
-            pass
 
         return today
     

--- a/workflow/preview.py
+++ b/workflow/preview.py
@@ -39,6 +39,15 @@ class EventPreview:
             'mon': 0, 'tue': 1, 'wed': 2, 'thu': 3,
             'fri': 4, 'sat': 5, 'sun': 6
         }
+        self.month_map = {
+            'january': 1, 'february': 2, 'march': 3, 'april': 4, 'may': 5, 'june': 6,
+            'july': 7, 'august': 8, 'september': 9, 'october': 10, 'november': 11, 'december': 12,
+            'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'jun': 6, 'jul': 7,
+            'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12
+        }
+        self.date_range_pattern = r'from\s+(\w+\s+\d{1,2}|\d{1,2}/\d{1,2}(?:/\d{2,4})?)\s*(?:-|to)\s*(\w+\s+\d{1,2}|\d{1,2}/\d{1,2}(?:/\d{2,4})?)'
+        # Require am/pm for bare hours to avoid matching date numbers like "20" in "March 20"
+        self.time_pattern = r'\b(\d{1,2}):(\d{2})\s*(am|pm)?\b|\b(\d{1,2})\s*(am|pm)\b'
 
     def get_calendar(self, text: str) -> str:
         """Extract calendar name from text or use default"""
@@ -53,20 +62,103 @@ class EventPreview:
         return self.default_calendar
 
     def parse_time(self, text: str) -> Optional[datetime]:
-        """Parse time from text"""
+        """Parse time from text - requires am/pm for bare hours to avoid matching date numbers"""
         match = re.search(self.time_pattern, text, re.IGNORECASE)
         if match:
-            hour = int(match.group(1))
-            minutes = int(match.group(2)) if match.group(2) else 0
-            meridiem = match.group(3).lower() if match.group(3) else ''
-            
+            if match.group(1) is not None:  # HH:MM format
+                hour = int(match.group(1))
+                minutes = int(match.group(2))
+                meridiem = match.group(3).lower() if match.group(3) else ''
+            else:  # bare number with required am/pm
+                hour = int(match.group(4))
+                minutes = 0
+                meridiem = match.group(5).lower()
+
             if meridiem == 'pm' and hour != 12:
                 hour += 12
             elif meridiem == 'am' and hour == 12:
                 hour = 0
-            
+
             now = datetime.now()
             return now.replace(hour=hour, minute=minutes, second=0, microsecond=0)
+        return None
+
+    def parse_duration(self, text: str) -> Optional[int]:
+        """Extract duration in minutes from text. Returns None if no duration found."""
+        # Time range like "3-5pm" or "3pm-5pm"
+        range_match = re.search(
+            r'(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*-\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)',
+            text, re.IGNORECASE
+        )
+        if range_match:
+            sh, sm, smer, eh, em, emer = range_match.groups()
+            sh, eh = int(sh), int(eh)
+            sm, em = int(sm or 0), int(em or 0)
+            # Propagate end meridiem to start when start has none
+            if not smer and emer:
+                smer = emer
+            if smer and smer.lower() == 'pm' and sh != 12: sh += 12
+            if emer and emer.lower() == 'pm' and eh != 12: eh += 12
+            diff = (eh * 60 + em) - (sh * 60 + sm)
+            if diff > 0:
+                return diff
+
+        # "for X hours" (including decimals like 1.5h)
+        m = re.search(r'for\s+(\d+(?:\.\d+)?)\s*hours?', text, re.IGNORECASE)
+        if m:
+            return int(float(m.group(1)) * 60)
+
+        # "for X minutes" / "for Xmin"
+        m = re.search(r'for\s+(\d+)\s*min(?:ute)?s?', text, re.IGNORECASE)
+        if m:
+            return int(m.group(1))
+
+        return None
+
+    def parse_time_start(self, text: str) -> Optional[datetime]:
+        """Like parse_time but returns the START of a time range (e.g. 3pm from 3-5pm)"""
+        # Check for time range first — return start hour
+        range_match = re.search(
+            r'(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*-\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)',
+            text, re.IGNORECASE
+        )
+        if range_match:
+            sh, sm, smer, _, _, emer = range_match.groups()
+            sh = int(sh)
+            sm = int(sm or 0)
+            # Propagate end meridiem to start when start has none
+            if not smer and emer:
+                smer = emer
+            if smer and smer.lower() == 'pm' and sh != 12: sh += 12
+            elif smer and smer.lower() == 'am' and sh == 12: sh = 0
+            now = datetime.now()
+            return now.replace(hour=sh, minute=sm, second=0, microsecond=0)
+        return self.parse_time(text)
+
+    def parse_explicit_date(self, text: str) -> Optional[datetime]:
+        """Extract explicit month+day dates like 'March 20', '20 March', or '3/20'"""
+        month_names = '|'.join(self.month_map.keys())
+        # Try "Day Month" first to avoid mismatching time digits (e.g. "march 15" in "15:15")
+        match = re.search(rf'\b(\d{{1,2}})\s+({month_names})\b', text, re.IGNORECASE)
+        if match:
+            day = int(match.group(1))
+            month = self.month_map[match.group(2).lower()]
+        else:
+            # Negative lookahead: exclude digits followed by ":" (part of HH:MM)
+            match = re.search(rf'\b({month_names})\s+(\d{{1,2}})(?!:\d{{2}})\b', text, re.IGNORECASE)
+            if match:
+                month = self.month_map[match.group(1).lower()]
+                day = int(match.group(2))
+            else:
+                return None
+        today = datetime.now()
+        try:
+            result = datetime(today.year, month, day)
+            if result.date() < today.date():
+                result = datetime(today.year + 1, month, day)
+            return result
+        except ValueError:
+            pass
         return None
 
     def get_next_weekday(self, weekday_name: str) -> datetime:
@@ -87,7 +179,7 @@ class EventPreview:
         text_lower = text.lower()
         today = datetime.now()
         target_date = None
-        target_time = self.parse_time(text_lower)
+        target_time = self.parse_time_start(text)
 
         # Handle recurring events
         if 'every' in text_lower:
@@ -96,6 +188,15 @@ class EventPreview:
                     if target_time:
                         return f"Every {day.capitalize()} at {target_time.strftime('%-I:%M %p')}"
                     return f"Every {day.capitalize()}"
+
+        # Handle date ranges
+        range_match = re.search(self.date_range_pattern, text, re.IGNORECASE)
+        if range_match:
+            start_date = self.parse_explicit_date(range_match.group(1))
+            end_date = self.parse_explicit_date(range_match.group(2))
+            if start_date:
+                end_label = end_date.strftime("%b %-d") if end_date else range_match.group(2)
+                return f"{start_date.strftime('%A, %B %-d')} → {end_label}"
 
         # Handle weekdays
         for day in self.weekdays:
@@ -108,7 +209,12 @@ class EventPreview:
             target_date = today + timedelta(days=1)
         elif 'next week' in text_lower:
             target_date = today + timedelta(days=7)
-        elif not target_date:
+
+        # Handle explicit dates like "March 20"
+        if not target_date:
+            target_date = self.parse_explicit_date(text)
+
+        if not target_date:
             target_date = today
 
         # Set time if specified
@@ -118,34 +224,56 @@ class EventPreview:
                 minute=target_time.minute
             )
 
+        # Build time string — always show end time (default 60 min if no duration specified)
+        def time_range_str(start: datetime) -> str:
+            if not target_time:
+                return ""
+            duration = self.parse_duration(text) or 60
+            end = start + timedelta(minutes=duration)
+            return f" at {start.strftime('%-I:%M %p')} – {end.strftime('%-I:%M %p')}"
+
         # Format output
-        if not target_date:
-            return "Invalid date"
-        
         if target_date.date() == today.date():
-            return f"Today at {target_date.strftime('%-I:%M %p')}"
+            return f"Today{time_range_str(target_date)}"
         elif target_date.date() == (today + timedelta(days=1)).date():
-            return f"Tomorrow at {target_date.strftime('%-I:%M %p')}"
-        return target_date.strftime("%A, %B %-d at %-I:%M %p")
+            return f"Tomorrow{time_range_str(target_date)}"
+        return target_date.strftime("%A, %B %-d") + time_range_str(target_date)
 
     def clean_title(self, text: str) -> str:
         """Clean title from input text"""
         # Remove calendar tag
         text = re.sub(self.calendar_pattern, '', text)
-        
-        # Remove date/time patterns
+
         patterns_to_remove = [
-            r'\b(?:tomorrow|today|next|on|at|from|to|every|daily|weekly|monthly)\b.*$',
-            r'\d{1,2}(?::(\d{2}))?\s*(?:am|pm).*$',
-            r'for\s+\d+\s+(?:day|hour|minute|min)s?.*$',
-            r'(?:alert|remind).*$',
-            r'with\s+\d+\s*(?:minute|min|hour)s?\s+(?:alert|reminder)',
-            r'(?:^|\s)(?:at|in)\s+([^,\.\d][^,\.]*?)(?=\s+|$)'
+            # Recurrence
+            r'\bevery\s+\w+',
+            r'\bdaily\b|\bweekly\b|\bmonthly\b|\bannually\b|\byearly\b',
+            # Weekdays
+            r'\b(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b',
+            # Relative dates
+            r'\btomorrow\b|\btoday\b',
+            r'\bnext\s+(?:week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b',
+            # Explicit dates: "March 20", "20 March"
+            r'\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?!:\d{2})\b',
+            r'\b\d{1,2}(?!:\d{2})\s+(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b',
+            # Time ranges like "3-5pm" — must come before bare time patterns
+            r'\b\d{1,2}(?::\d{2})?\s*(?:am|pm)?\s*-\s*\d{1,2}(?::\d{2})?\s*(?:am|pm)\b',
+            # Time
+            r'\bat\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?\b',
+            r'\b\d{1,2}:\d{2}\s*(?:am|pm)?\b',
+            r'\b\d{1,2}\s*(?:am|pm)\b',
+            # Duration (with or without space before unit)
+            r'\bfor\s+\d+(?:\.\d+)?\s*(?:day|hour|hr|minute|min)s?\b',
+            # Alerts
+            r'\bwith\s+\d+\s*(?:minute|min|hour)s?\s+(?:alert|reminder)\b',
+            r'\b(?:alert|remind)\s+\d+\s*(?:minute|min|hour)s?\s+before\b',
+            # Prepositions
+            r'\bfrom\b|\bto\b|\bon\b|\bat\b|\bin\b',
         ]
-        
+
         for pattern in patterns_to_remove:
             text = re.sub(pattern, '', text, flags=re.IGNORECASE)
-        
+
         return ' '.join(text.split())
 
     def parse_location(self, text: str) -> Optional[str]:
@@ -156,8 +284,29 @@ class EventPreview:
             return location
         return None
 
+    def expand_shorthands(self, text: str) -> str:
+        """Expand common shorthand terms before parsing"""
+        replacements = [
+            (r'\btmrw\b|\btmr\b|\btmro\b', 'tomorrow'),
+            (r'\btod\b|\btdy\b', 'today'),
+            (r'\bnxt wk\b|\bnxt week\b|\bnw\b', 'next week'),
+            (r'\bw/\b', 'with'),
+            (r'\beve\b', 'evening'),
+            (r'\bmtg\b|\bmeet\b', 'meeting'),
+            (r'\bapt\b|\bappt\b', 'appointment'),
+            (r'\bdr\b', 'doctor'),
+            (r'\bwfh\b', 'work from home'),
+            (r'\b(\d+)m\b(?!arch|ay)', 'for \\1 minutes'),
+            (r'\b(\d+)h\b(?!our)', 'for \\1 hours'),
+        ]
+        result = text
+        for pattern, replacement in replacements:
+            result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+        return result
+
     def generate_items(self, text: str) -> List[dict]:
         """Generate preview items"""
+        text = self.expand_shorthands(text)
         title = self.clean_title(text)
         calendar = self.get_calendar(text)
         date = self.parse_date(text)

--- a/workflow/preview.py
+++ b/workflow/preview.py
@@ -8,6 +8,14 @@ import re
 from datetime import datetime, timedelta
 from typing import Optional, List
 
+# Add local lib dir so dateutil resolves to the bundled copy
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lib'))
+try:
+    from dateutil import parser as dateutil_parser
+    _HAS_DATEUTIL = True
+except ImportError:
+    _HAS_DATEUTIL = False
+
 def get_workflow_data_dir():
     """Get Alfred workflow data directory"""
     data_dir = os.getenv('alfred_workflow_data')
@@ -198,21 +206,24 @@ class EventPreview:
                 end_label = end_date.strftime("%b %-d") if end_date else range_match.group(2)
                 return f"{start_date.strftime('%A, %B %-d')} → {end_label}"
 
-        # Handle weekdays
-        for day in self.weekdays:
-            if day in text_lower:
-                target_date = self.get_next_weekday(day)
-                break
-
         # Handle relative dates
         if 'tomorrow' in text_lower:
             target_date = today + timedelta(days=1)
         elif 'next week' in text_lower:
             target_date = today + timedelta(days=7)
 
-        # Handle explicit dates like "March 20"
+        # Handle explicit dates like "March 20", "24 March", "Tuesday 24 March".
+        # This must run before bare weekday matching so "Tuesday 24 March" resolves
+        # to March 24, not next Tuesday.
         if not target_date:
             target_date = self.parse_explicit_date(text)
+
+        # Fall back to weekday-only matching (e.g., "meeting on Thursday")
+        if not target_date:
+            for day in self.weekdays:
+                if day in text_lower:
+                    target_date = self.get_next_weekday(day)
+                    break
 
         if not target_date:
             target_date = today


### PR DESCRIPTION
- Fix time_pattern to require am/pm for bare hours, preventing date numbers (e.g. '20' in 'March 20') from being matched as times
- Fix _get_base_date to parse explicit dates ('March 20', '17 March') using dateutil fuzzy parsing, not just relative/weekday keywords
- Fix parse_explicit_date in preview to try 'Day Month' order first, with negative lookahead to avoid matching HH:MM digits as date numbers
- Fix time range parsing ('3-5pm') to correctly propagate meridiem to start hour and return the correct start time from parse_time
- Fix parse_duration to correctly compute range durations with meridiem
- Fix clean_title to use targeted removals instead of greedy patterns, so event title words after a date/time are preserved
- Add expand_shorthands(): tmrw, tmr, mtg, appt, dr, wfh, 2h, 30m etc.
- Preview now shows start-end time range (default +60 min if no duration)
- Notification output now includes end time alongside start time